### PR TITLE
Start the server before running tests.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,8 @@ var (
 )
 
 func init() {
+	go main()
+	time.Sleep(1*time.Millisecond)
 	c, err = NewClient(dsn, time.Millisecond*500)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This helps to run tests a bit easily. Run the server in a separate go thread
before starting to run tests.